### PR TITLE
PAPP-20233 changed from md5 to sha256 for FIPS compliance

### DIFF
--- a/process_email.py
+++ b/process_email.py
@@ -1154,7 +1154,7 @@ class ProcessEmail(object):
             self._base_connector.debug_print('Handled exception in _create_dict_hash', e)
             return None
 
-        return hashlib.md5(input_dict_str).hexdigest()
+        return hashlib.sha256(input_dict_str).hexdigest()
 
     def _del_tmp_dirs(self):
         """Remove any tmp_dirs that were created."""


### PR DESCRIPTION
Note: Code that was changed is actually only used during the "on poll" action, which is not used in this particular app at this time. It appears that the MS Graph app was written using the Office 365 app code, which did contain the "on poll" action.