### PR TITLE
Add default charset

### DIFF
--- a/process_email.py
+++ b/process_email.py
@@ -15,6 +15,7 @@
 import email
 import hashlib
 import json
+import locale
 import mimetypes
 import os
 import re
@@ -575,7 +576,7 @@ class ProcessEmail:
         return self._decode_uni_string(subject, def_cont_name)
 
     def _handle_if_body(self, content_disp, content_id, content_type, part, bodies, file_path):
-        content_charset = part.get_content_charset()
+        content_charset = part.get_content_charset(failobj=locale.getencoding())
         process_as_body = False
 
         # if content disposition is None then assume that it is
@@ -618,7 +619,7 @@ class ProcessEmail:
         with open(file_path, "wb") as f:
             f.write(part_payload)
 
-        bodies.append({"file_path": file_path, "charset": part.get_content_charset()})
+        bodies.append({"file_path": file_path, "charset": part.get_content_charset(failobj=locale.getencoding())})
 
         return (phantom.APP_SUCCESS, False)
 
@@ -863,7 +864,7 @@ class ProcessEmail:
 
         extract_attach = self._config[PROC_EMAIL_JSON_EXTRACT_ATTACHMENTS]
 
-        charset = mail.get_content_charset()
+        charset = mail.get_content_charset(failobj=locale.getencoding())
 
         if charset is None:
             charset = "utf-8"
@@ -913,7 +914,7 @@ class ProcessEmail:
             file_path = f"{tmp_dir}/part_1.text"
             with open(file_path, "wb") as f:
                 f.write(mail.get_payload(decode=True))
-            bodies.append({"file_path": file_path, "charset": mail.get_content_charset()})
+            bodies.append({"file_path": file_path, "charset": mail.get_content_charset(failobj=locale.getencoding())})
 
         # get the container name
         container_name = self._get_container_name(self._parsed_mail, email_id)

--- a/process_email.py
+++ b/process_email.py
@@ -748,12 +748,7 @@ class ProcessEmail:
     def _get_email_headers_from_part(self, part, charset=None):
         email_headers = list(part.items())
 
-        # TODO: the next 2 ifs can be condensed to use 'or'
-        if charset is None:
-            charset = part.get_content_charset()
-
-        if charset is None:
-            charset = "utf8"
+        charset = charset or part.get_content_charset(failobj="utf8")
 
         if not email_headers:
             return {}


### PR DESCRIPTION
### Bug Fixes
Adding default charset to get_content_charset part to fix the ingestion issue where Content-Type header is missing

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md? N/A
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [X] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
