### PR TITLE
fix: complete Graph validation follow-ups

### DIFF
--- a/office365_connector.py
+++ b/office365_connector.py
@@ -700,6 +700,7 @@ class Office365Connector(BaseConnector):
         data=None,
         method="get",
         download=False,
+        allow_redirects=True,
     ):
         resp_json = None
 
@@ -720,6 +721,7 @@ class Office365Connector(BaseConnector):
                     verify=verify,
                     params=params,
                     timeout=MSGOFFICE365_DEFAULT_REQUEST_TIMEOUT,
+                    allow_redirects=allow_redirects,
                 )
             except Exception as e:
                 error_msg = _get_error_msg_from_exception(e, self)
@@ -729,6 +731,15 @@ class Office365Connector(BaseConnector):
                 break
             self.debug_print("Received 502 status code from the server")
             time.sleep(self._retry_wait_time)
+
+        if not allow_redirects and _is_redirect_status(r.status_code):
+            return RetVal(
+                action_result.set_status(
+                    phantom.APP_ERROR,
+                    "Refusing to follow a redirect from a Microsoft Graph pagination URL",
+                ),
+                None,
+            )
 
         if download:
             if 200 <= r.status_code < 399:
@@ -870,7 +881,17 @@ class Office365Connector(BaseConnector):
 
         headers.update({"Authorization": f"Bearer {self._access_token}", "Accept": "application/json", "Content-Type": "application/json"})
 
-        ret_val, resp_json = self._make_rest_call(action_result, url, verify, headers, params, data, method, download=download)
+        ret_val, resp_json = self._make_rest_call(
+            action_result,
+            url,
+            verify,
+            headers,
+            params,
+            data,
+            method,
+            download=download,
+            allow_redirects=not bool(nextLink),
+        )
 
         # If token is expired, generate a new token
         msg = action_result.get_message()
@@ -891,6 +912,7 @@ class Office365Connector(BaseConnector):
                 data,
                 method,
                 download=download,
+                allow_redirects=not bool(nextLink),
             )
 
         if phantom.is_fail(ret_val):

--- a/office365_connector.py
+++ b/office365_connector.py
@@ -397,6 +397,15 @@ def _handle_oauth_start(request, path_parts):
             status=400,
         )
 
+    presented_start_nonce = str(request.GET.get("start_nonce") or "")
+    stored_start_nonce = str(state.get("start_nonce") or "")
+    if not stored_start_nonce or not hmac.compare_digest(stored_start_nonce, presented_start_nonce):
+        return HttpResponse(
+            "ERROR: OAuth start request did not match the pending authorization flow",
+            content_type="text/plain",
+            status=400,
+        )
+
     # get the url to point to the authorize url of OAuth
     admin_consent_url = state.get("admin_consent_url")
 
@@ -405,6 +414,14 @@ def _handle_oauth_start(request, path_parts):
             "App state is invalid, admin_consent_url key not found",
             content_type="text/plain",
             status=400,
+        )
+
+    state.pop("start_nonce", None)
+    if _save_app_state(state, asset_id) != phantom.APP_SUCCESS:
+        return HttpResponse(
+            "ERROR: Unable to consume the pending OAuth start request",
+            content_type="text/plain",
+            status=500,
         )
 
     # Redirect to this link, the user will then require to enter credentials interactively
@@ -3654,6 +3671,8 @@ class Office365Connector(BaseConnector):
         app_state["redirect_uri"] = redirect_uri
         flow_nonce = secrets.token_urlsafe(32)
         app_state["flow_nonce"] = flow_nonce
+        start_nonce = secrets.token_urlsafe(32)
+        app_state["start_nonce"] = start_nonce
         oauth_state = urllib.parse.quote(f"{self._asset_id}:{flow_nonce}", safe="")
 
         self.save_progress("Using OAuth Redirect URL as:")
@@ -3682,7 +3701,8 @@ class Office365Connector(BaseConnector):
 
         # The URL that the user should open in a different tab.
         # This is pointing to a REST endpoint that points to the app
-        url_to_show = f"{app_rest_url}/start_oauth?asset_id={self._asset_id}&"
+        start_query = urllib.parse.urlencode({"asset_id": self._asset_id, "start_nonce": start_nonce})
+        url_to_show = f"{app_rest_url}/start_oauth?{start_query}"
 
         # Save the state, will be used by the request handler
         _save_app_state(app_state, self._asset_id, self)

--- a/office365_connector.py
+++ b/office365_connector.py
@@ -60,7 +60,16 @@ MSGOFFICE365_UPLOAD_HOSTS = {"graph.microsoft.com", "outlook.office.com"}
 
 def _quote_path_segment(value):
     """Encode a caller-controlled value as one Microsoft Graph path segment."""
-    return urllib.parse.quote(str(value), safe="")
+    raw_value = str(value)
+    canonical_value = raw_value
+    for _ in range(5):
+        decoded_value = urllib.parse.unquote(canonical_value)
+        if decoded_value == canonical_value:
+            break
+        canonical_value = decoded_value
+    if canonical_value in {".", ".."}:
+        raise ValueError("Microsoft Graph path identifiers must not be dot segments")
+    return urllib.parse.quote(raw_value, safe="")
 
 
 def _is_expected_graph_url(url):
@@ -1280,9 +1289,9 @@ class Office365Connector(BaseConnector):
 
         container["name"] = email["subject"] if email["subject"] else email["id"]
         container_description = MSGOFFICE365_CONTAINER_DESCRIPTION.format(last_modified_time=email["lastModifiedDateTime"])
-        container["description"] = container_description
+        container["description"] = f"{container_description} (ingestion pending)"
         container["source_data_identifier"] = email["id"]
-        container["data"] = {"raw_email": email}
+        container["data"] = {"raw_email": email, "ingestion_complete": False}
 
         ret_val, msg, container_id = self.save_container(container)
 
@@ -1291,9 +1300,9 @@ class Office365Connector(BaseConnector):
 
         if MSGOFFICE365_DUPLICATE_CONTAINER_FOUND_MSG in msg.lower():
             self.debug_print("Duplicate container found")
-            self._duplicate_count += 1
 
-            # Prevent further processing if the email is not modified
+            # Skip only containers that explicitly completed ingestion. Legacy and
+            # interrupted containers have no completion marker and are retried once.
             ret_val, container_info, status_code = self.get_container_info(container_id=container_id)
             if phantom.is_fail(ret_val):
                 return action_result.set_status(
@@ -1301,16 +1310,12 @@ class Office365Connector(BaseConnector):
                     f"Status Code: {status_code}. Error occurred while fetching the container info for container ID: {container_id}",
                 )
 
-            if container_info.get("description", "") == container_description:
+            container_data = container_info.get("data") if isinstance(container_info.get("data"), dict) else {}
+            if container_info.get("description", "") == container_description and container_data.get("ingestion_complete") is True:
+                self._duplicate_count += 1
                 msg = "Email ID: {} has not been modified. Hence, skipping the artifact ingestion.".format(email["id"])
                 self.debug_print(msg)
                 return action_result.set_status(phantom.APP_SUCCESS, msg)
-            else:
-                # Update the container's description and continue
-                self.debug_print("Updating container's description")
-                ret_val = self._update_container(action_result, container_id, container)
-                if phantom.is_fail(ret_val):
-                    return action_result.get_status()
 
         self.debug_print("Creating email artifacts")
         email_artifacts = self._create_email_artifacts(container_id, email)
@@ -1372,6 +1377,12 @@ class Office365Connector(BaseConnector):
         ret_val, msg, container_id = self.save_artifacts(artifacts)
         if phantom.is_fail(ret_val):
             return action_result.set_status(phantom.APP_ERROR, msg)
+
+        container["description"] = container_description
+        container["data"]["ingestion_complete"] = True
+        ret_val = self._update_container(action_result, container_id, container)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
 
         return phantom.APP_SUCCESS
 
@@ -2770,6 +2781,7 @@ class Office365Connector(BaseConnector):
                             upload_url,
                             headers=headers,
                             data=file_content,
+                            allow_redirects=False,
                             timeout=MSGOFFICE365_DEFAULT_REQUEST_TIMEOUT,
                         )
                     except Exception as e:

--- a/office365_connector.py
+++ b/office365_connector.py
@@ -55,6 +55,10 @@ MSGOFFICE365_DEFAULT_SCOPE = "https://graph.microsoft.com/.default"
 MSGOFFICE365_MAX_PAGINATION_PAGES = 1000
 MSGOFFICE365_MAX_POLL_CYCLES = 100
 MSGOFFICE365_MAX_ATTACHMENT_DEPTH = 10
+MSGOFFICE365_LATEST_FIRST_NEXT_LINK = "latest_first_next_link"
+MSGOFFICE365_LATEST_FIRST_HIGH_WATER = "latest_first_high_water"
+MSGOFFICE365_LATEST_FIRST_SCOPE = "latest_first_scope"
+MSGOFFICE365_LATEST_FIRST_PAGE_SIZE = "latest_first_page_size"
 MSGOFFICE365_UPLOAD_HOSTS = {"graph.microsoft.com", "outlook.office.com"}
 
 
@@ -114,6 +118,10 @@ def _is_expected_upload_url(url):
         and not candidate.username
         and not candidate.password
     )
+
+
+def _is_redirect_status(status_code):
+    return 300 <= status_code < 400
 
 
 def _is_token_response(response):
@@ -526,6 +534,9 @@ class Office365Connector(BaseConnector):
         access_token = state.get("admin_auth", {}).get("access_token")
         if access_token:
             state["admin_auth"]["access_token"] = self.update_state_fields(access_token, helper_function, error_message)
+        continuation = state.get(MSGOFFICE365_LATEST_FIRST_NEXT_LINK)
+        if continuation:
+            state[MSGOFFICE365_LATEST_FIRST_NEXT_LINK] = self.update_state_fields(continuation, helper_function, error_message)
         return state
 
     def _decrypt_state(self, state):
@@ -2151,6 +2162,126 @@ class Office365Connector(BaseConnector):
         limit = expected_duplicate_count_in_next_cycle + remaining_count
         return limit, total_ingested
 
+    def _fetch_poll_page(self, action_result, endpoint, params=None, next_link=None):
+        ret_val, response = self._make_rest_call_helper(
+            action_result,
+            endpoint,
+            nextLink=next_link,
+            params=params,
+        )
+        if phantom.is_fail(ret_val):
+            return action_result.get_status(), None, None
+
+        continuation = response.get("@odata.nextLink")
+        if continuation and continuation == next_link:
+            return (
+                action_result.set_status(
+                    phantom.APP_ERROR,
+                    "Microsoft Graph pagination returned a repeated nextLink",
+                ),
+                None,
+                None,
+            )
+
+        return phantom.APP_SUCCESS, response.get("value") or [], continuation
+
+    def _clear_latest_first_poll_state(self):
+        for key in (
+            MSGOFFICE365_LATEST_FIRST_NEXT_LINK,
+            MSGOFFICE365_LATEST_FIRST_HIGH_WATER,
+            MSGOFFICE365_LATEST_FIRST_SCOPE,
+            MSGOFFICE365_LATEST_FIRST_PAGE_SIZE,
+        ):
+            self._state.pop(key, None)
+
+    def _handle_latest_first_poll(self, action_result, config, endpoint, params, max_emails):
+        continuation = self._state.get(MSGOFFICE365_LATEST_FIRST_NEXT_LINK)
+        saved_scope = self._state.get(MSGOFFICE365_LATEST_FIRST_SCOPE)
+        high_water = self._state.get(MSGOFFICE365_LATEST_FIRST_HIGH_WATER)
+
+        if not continuation and (saved_scope or high_water):
+            self._clear_latest_first_poll_state()
+            saved_scope = None
+            high_water = None
+
+        if continuation and saved_scope != endpoint:
+            self._clear_latest_first_poll_state()
+            continuation = None
+            high_water = None
+
+        if continuation:
+            page_size = self._state.get(MSGOFFICE365_LATEST_FIRST_PAGE_SIZE, max_emails)
+        else:
+            page_size = min(max_emails, MSGOFFICE365_PER_PAGE_COUNT)
+
+        page_size = max(1, page_size)
+        poll_budget = max(max_emails, page_size) if continuation else max_emails
+        request_params = None if continuation else dict(params, **{"$top": page_size})
+        processed = 0
+
+        for _ in range(MSGOFFICE365_MAX_POLL_CYCLES):
+            ret_val, emails, next_link = self._fetch_poll_page(
+                action_result,
+                endpoint,
+                params=request_params,
+                next_link=continuation,
+            )
+            if phantom.is_fail(ret_val):
+                return action_result.get_status()
+
+            if emails and not high_water:
+                high_water = datetime.strptime(emails[0]["lastModifiedDateTime"], O365_TIME_FORMAT).strftime(O365_TIME_FORMAT)
+
+            failed_email_ids = []
+            for index, email in enumerate(emails):
+                try:
+                    self.send_progress("Processing email # {} with ID ending in: {}".format(index + 1, email["id"][-10:]))
+                    ret_val = self._process_email_data(config, action_result, endpoint, email)
+                    if phantom.is_fail(ret_val):
+                        failed_email_ids.append(email.get("id"))
+                        self.debug_print("Error occurred while processing email ID: {}. {}".format(email.get("id"), action_result.get_message()))
+                except Exception as e:
+                    failed_email_ids.append(email.get("id"))
+                    error_msg = _get_error_msg_from_exception(e, self)
+                    self.debug_print(f"Exception occurred while processing email ID: {email.get('id')}. {error_msg}")
+
+            if failed_email_ids:
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Failed to process {len(failed_email_ids)} of {len(emails)} fetched emails; the polling continuation was not advanced",
+                )
+
+            processed += len(emails)
+            if next_link:
+                self._state[MSGOFFICE365_LATEST_FIRST_NEXT_LINK] = next_link
+                self._state[MSGOFFICE365_LATEST_FIRST_HIGH_WATER] = high_water
+                self._state[MSGOFFICE365_LATEST_FIRST_SCOPE] = endpoint
+                self._state[MSGOFFICE365_LATEST_FIRST_PAGE_SIZE] = page_size
+                self.save_state(deepcopy(self._state))
+
+                if processed + page_size > poll_budget:
+                    return action_result.set_status(phantom.APP_SUCCESS)
+
+                continuation = next_link
+                request_params = None
+                continue
+
+            self._clear_latest_first_poll_state()
+            if high_water:
+                self._state["last_time"] = high_water
+                if self._state.get("first_run", True):
+                    self._state["first_run"] = False
+            self.save_state(deepcopy(self._state))
+
+            if not emails and not processed:
+                return action_result.set_status(phantom.APP_SUCCESS, MSGOFFICE365_NO_DATA_FOUND)
+            return action_result.set_status(phantom.APP_SUCCESS)
+
+        return action_result.set_status(
+            phantom.APP_ERROR,
+            f"Polling exceeded the safety limit of {MSGOFFICE365_MAX_POLL_CYCLES} ingestion cycles",
+        )
+
     def _handle_on_poll(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
         action_result = self.add_action_result(ActionResult(dict(param)))
@@ -2217,6 +2348,13 @@ class Office365Connector(BaseConnector):
 
         cur_limit = max_emails
         total_ingested = 0
+
+        if not self.is_poll_now() and ingest_manner == "latest first":
+            return self._handle_latest_first_poll(action_result, config, endpoint, params, max_emails)
+
+        if not self.is_poll_now() and self._state.get(MSGOFFICE365_LATEST_FIRST_NEXT_LINK):
+            self._clear_latest_first_poll_state()
+            self.save_state(deepcopy(self._state))
 
         # Checkpoint the oldest fetched email in either ordering so a capped latest-first
         # batch does not advance past the remainder of the mailbox window.
@@ -2787,6 +2925,15 @@ class Office365Connector(BaseConnector):
                     except Exception as e:
                         error_msg = _get_error_msg_from_exception(e, self)
                         return action_result.set_status(phantom.APP_ERROR, f"Failed to upload file. {error_msg}"), None
+
+                    if _is_redirect_status(response.status_code):
+                        return (
+                            action_result.set_status(
+                                phantom.APP_ERROR,
+                                f"Failed to upload file: Microsoft Graph returned redirect status {response.status_code}",
+                            ),
+                            None,
+                        )
 
                     if response.status_code != 429:
                         if not response.ok:

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,5 @@
 **Unreleased**
+
+* Reject exact and nested-encoded dot segments in Microsoft Graph path identifiers.
+* Disable redirects while uploading attachment bytes to Microsoft upload sessions.
+* Retry legacy or interrupted email ingestion until artifacts and the completion marker are saved.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Reject redirects while following Microsoft Graph pagination links.
 * Retry legacy or interrupted email ingestion until artifacts and the completion marker are saved.
 * Resume capped latest-first polling windows before advancing the mailbox checkpoint.
+* Require a one-time nonce before starting an interactive OAuth authorization flow.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,5 +3,6 @@
 * Reject exact and nested-encoded dot segments in Microsoft Graph path identifiers.
 * Disable redirects while uploading attachment bytes to Microsoft upload sessions.
 * Reject redirect responses from Microsoft attachment upload sessions.
+* Reject redirects while following Microsoft Graph pagination links.
 * Retry legacy or interrupted email ingestion until artifacts and the completion marker are saved.
 * Resume capped latest-first polling windows before advancing the mailbox checkpoint.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,4 +2,6 @@
 
 * Reject exact and nested-encoded dot segments in Microsoft Graph path identifiers.
 * Disable redirects while uploading attachment bytes to Microsoft upload sessions.
+* Reject redirect responses from Microsoft attachment upload sessions.
 * Retry legacy or interrupted email ingestion until artifacts and the completion marker are saved.
+* Resume capped latest-first polling windows before advancing the mailbox checkpoint.

--- a/tests/test_validation_followup.py
+++ b/tests/test_validation_followup.py
@@ -49,9 +49,7 @@ class ValidationFollowupTests(unittest.TestCase):
         tree = ast.parse(source)
         handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_upload_large_attachment")
         put_calls = [
-            node
-            for node in ast.walk(handler)
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "put"
+            node for node in ast.walk(handler) if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "put"
         ]
         self.assertEqual(len(put_calls), 1)
         redirect_keyword = next((keyword for keyword in put_calls[0].keywords if keyword.arg == "allow_redirects"), None)

--- a/tests/test_validation_followup.py
+++ b/tests/test_validation_followup.py
@@ -14,6 +14,8 @@
 import ast
 import unittest
 import urllib.parse
+from copy import deepcopy
+from datetime import datetime
 from pathlib import Path
 
 
@@ -29,10 +31,77 @@ def _load_quote_helper():
     return namespace["_quote_path_segment"]
 
 
+def _load_redirect_helper():
+    source = CONNECTOR.read_text()
+    tree = ast.parse(source)
+    helper = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_is_redirect_status")
+    namespace = {}
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[helper], type_ignores=[])), str(CONNECTOR), "exec"), namespace)
+    return namespace["_is_redirect_status"]
+
+
+def _load_polling_policy():
+    source = CONNECTOR.read_text()
+    tree = ast.parse(source)
+    connector = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Office365Connector")
+    methods = [
+        node
+        for node in connector.body
+        if isinstance(node, ast.FunctionDef) and node.name in {"_clear_latest_first_poll_state", "_handle_latest_first_poll"}
+    ]
+    policy = ast.ClassDef(
+        name="PollingPolicy",
+        bases=[],
+        keywords=[],
+        body=methods,
+        decorator_list=[],
+    )
+
+    class PhantomStub:
+        APP_SUCCESS = 0
+        APP_ERROR = 1
+
+        @staticmethod
+        def is_fail(status):
+            return status != PhantomStub.APP_SUCCESS
+
+    namespace = {
+        "deepcopy": deepcopy,
+        "datetime": datetime,
+        "phantom": PhantomStub,
+        "O365_TIME_FORMAT": "%Y-%m-%dT%H:%M:%SZ",
+        "MSGOFFICE365_LATEST_FIRST_NEXT_LINK": "latest_first_next_link",
+        "MSGOFFICE365_LATEST_FIRST_HIGH_WATER": "latest_first_high_water",
+        "MSGOFFICE365_LATEST_FIRST_SCOPE": "latest_first_scope",
+        "MSGOFFICE365_LATEST_FIRST_PAGE_SIZE": "latest_first_page_size",
+        "MSGOFFICE365_PER_PAGE_COUNT": 999,
+        "MSGOFFICE365_MAX_POLL_CYCLES": 100,
+        "MSGOFFICE365_NO_DATA_FOUND": "No data found",
+        "_get_error_msg_from_exception": lambda error, connector: str(error),
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[policy], type_ignores=[])), str(CONNECTOR), "exec"), namespace)
+    return namespace["PollingPolicy"], PhantomStub
+
+
+class PollingActionResult:
+    def __init__(self):
+        self.status = 0
+        self.message = ""
+
+    def set_status(self, status, message=""):
+        self.status = status
+        self.message = message
+        return status
+
+    def get_status(self):
+        return self.status
+
+
 class ValidationFollowupTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.quote_segment = staticmethod(_load_quote_helper())
+        cls.is_redirect_status = staticmethod(_load_redirect_helper())
 
     def test_path_helper_rejects_dot_segments_after_repeated_decoding(self):
         for value in (".", "..", "%2e", "%2e%2e", "%252e%252e", "%25252e%25252e"):
@@ -56,6 +125,118 @@ class ValidationFollowupTests(unittest.TestCase):
         self.assertIsNotNone(redirect_keyword)
         self.assertIsInstance(redirect_keyword.value, ast.Constant)
         self.assertIs(redirect_keyword.value.value, False)
+
+    def test_attachment_upload_rejects_every_redirect_response(self):
+        for status_code in (300, 301, 302, 303, 307, 308, 399):
+            with self.subTest(status_code=status_code):
+                self.assertTrue(self.is_redirect_status(status_code))
+        for status_code in (200, 299, 400, 429, 500):
+            with self.subTest(status_code=status_code):
+                self.assertFalse(self.is_redirect_status(status_code))
+
+        source = CONNECTOR.read_text()
+        tree = ast.parse(source)
+        handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_upload_large_attachment")
+        handler_source = ast.get_source_segment(source, handler)
+        self.assertLess(handler_source.index("_is_redirect_status(response.status_code)"), handler_source.index("if not response.ok"))
+
+    def test_latest_first_poll_persists_continuation_before_checkpoint(self):
+        source = CONNECTOR.read_text()
+        tree = ast.parse(source)
+        handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_handle_latest_first_poll")
+        handler_source = ast.get_source_segment(source, handler)
+
+        continuation_offset = handler_source.index("self._state[MSGOFFICE365_LATEST_FIRST_NEXT_LINK] = next_link")
+        continuation_save_offset = handler_source.index("self.save_state(deepcopy(self._state))", continuation_offset)
+        checkpoint_offset = handler_source.index('self._state["last_time"] = high_water')
+        clear_offset = handler_source.index("self._clear_latest_first_poll_state()", continuation_save_offset)
+
+        self.assertLess(continuation_offset, continuation_save_offset)
+        self.assertLess(continuation_save_offset, clear_offset)
+        self.assertLess(clear_offset, checkpoint_offset)
+        self.assertIn("if failed_email_ids:", handler_source[:continuation_offset])
+        self.assertIn("if next_link:", handler_source[:continuation_offset])
+        self.assertIn("processed + page_size > poll_budget", handler_source)
+
+    def test_latest_first_poll_resumes_before_committing_high_water(self):
+        polling_policy, phantom_stub = _load_polling_policy()
+
+        class Harness(polling_policy):
+            def __init__(self):
+                self._state = {"first_run": True}
+                self.pages = []
+                self.saved_states = []
+                self.processed_ids = []
+                self.failed_ids = set()
+
+            def _fetch_poll_page(self, action_result, endpoint, params=None, next_link=None):
+                return self.pages.pop(0)
+
+            def _process_email_data(self, config, action_result, endpoint, email):
+                self.processed_ids.append(email["id"])
+                if email["id"] in self.failed_ids:
+                    return phantom_stub.APP_ERROR
+                return phantom_stub.APP_SUCCESS
+
+            def save_state(self, state):
+                self.saved_states.append(deepcopy(state))
+
+            def send_progress(self, message):
+                pass
+
+            def debug_print(self, message):
+                pass
+
+        harness = Harness()
+        action_result = PollingActionResult()
+        harness.pages = [
+            (
+                phantom_stub.APP_SUCCESS,
+                [
+                    {"id": "newest", "lastModifiedDateTime": "2026-08-01T10:00:00Z"},
+                    {"id": "middle", "lastModifiedDateTime": "2026-08-01T09:00:00Z"},
+                ],
+                "https://graph.microsoft.com/v1.0/messages?$skiptoken=next",
+            )
+        ]
+
+        status = harness._handle_latest_first_poll(action_result, {}, "/users/u/messages", {"$orderBy": "desc"}, 2)
+        self.assertEqual(status, phantom_stub.APP_SUCCESS)
+        self.assertEqual(harness.processed_ids, ["newest", "middle"])
+        self.assertNotIn("last_time", harness._state)
+        self.assertEqual(harness._state["latest_first_high_water"], "2026-08-01T10:00:00Z")
+        self.assertIn("latest_first_next_link", harness._state)
+
+        saved_continuation_state = deepcopy(harness._state)
+        harness.failed_ids.add("oldest")
+        harness.pages = [
+            (
+                phantom_stub.APP_SUCCESS,
+                [{"id": "oldest", "lastModifiedDateTime": "2026-08-01T08:00:00Z"}],
+                None,
+            )
+        ]
+        status = harness._handle_latest_first_poll(action_result, {}, "/users/u/messages", {"$orderBy": "desc"}, 2)
+        self.assertEqual(status, phantom_stub.APP_ERROR)
+        self.assertEqual(harness._state, saved_continuation_state)
+        self.assertNotIn("last_time", harness._state)
+
+        harness.failed_ids.clear()
+        action_result = PollingActionResult()
+        harness.pages = [
+            (
+                phantom_stub.APP_SUCCESS,
+                [{"id": "oldest", "lastModifiedDateTime": "2026-08-01T08:00:00Z"}],
+                None,
+            )
+        ]
+        status = harness._handle_latest_first_poll(action_result, {}, "/users/u/messages", {"$orderBy": "desc"}, 2)
+        self.assertEqual(status, phantom_stub.APP_SUCCESS)
+        self.assertEqual(harness.processed_ids, ["newest", "middle", "oldest", "oldest"])
+        self.assertEqual(harness._state["last_time"], "2026-08-01T10:00:00Z")
+        self.assertFalse(harness._state["first_run"])
+        self.assertNotIn("latest_first_next_link", harness._state)
+        self.assertNotIn("latest_first_high_water", harness._state)
 
     def test_container_completion_marker_is_written_only_after_artifacts(self):
         source = CONNECTOR.read_text()

--- a/tests/test_validation_followup.py
+++ b/tests/test_validation_followup.py
@@ -83,6 +83,43 @@ def _load_polling_policy():
     return namespace["PollingPolicy"], PhantomStub
 
 
+def _load_rest_call_policy():
+    source = CONNECTOR.read_text()
+    tree = ast.parse(source)
+    connector = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Office365Connector")
+    method = next(node for node in connector.body if isinstance(node, ast.FunctionDef) and node.name == "_make_rest_call")
+    policy = ast.ClassDef(
+        name="RestCallPolicy",
+        bases=[],
+        keywords=[],
+        body=[method],
+        decorator_list=[],
+    )
+
+    class PhantomStub:
+        APP_SUCCESS = 0
+        APP_ERROR = 1
+
+    class RequestsStub:
+        def __init__(self):
+            self.kwargs = None
+
+        def get(self, url, **kwargs):
+            self.kwargs = kwargs
+            return type("Response", (), {"status_code": 302})()
+
+    requests_stub = RequestsStub()
+    namespace = {
+        "requests": requests_stub,
+        "phantom": PhantomStub,
+        "RetVal": lambda *values: values,
+        "_is_redirect_status": lambda status_code: 300 <= status_code < 400,
+        "MSGOFFICE365_DEFAULT_REQUEST_TIMEOUT": 30,
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[policy], type_ignores=[])), str(CONNECTOR), "exec"), namespace)
+    return namespace["RestCallPolicy"], requests_stub, PhantomStub
+
+
 class PollingActionResult:
     def __init__(self):
         self.status = 0
@@ -95,6 +132,17 @@ class PollingActionResult:
 
     def get_status(self):
         return self.status
+
+
+class RestCallActionResult:
+    def __init__(self):
+        self.status = 0
+        self.message = ""
+
+    def set_status(self, status, message=""):
+        self.status = status
+        self.message = message
+        return status
 
 
 class ValidationFollowupTests(unittest.TestCase):
@@ -139,6 +187,40 @@ class ValidationFollowupTests(unittest.TestCase):
         handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_upload_large_attachment")
         handler_source = ast.get_source_segment(source, handler)
         self.assertLess(handler_source.index("_is_redirect_status(response.status_code)"), handler_source.index("if not response.ok"))
+
+    def test_pagination_get_rejects_redirect_without_following_it(self):
+        rest_call_policy, requests_stub, phantom_stub = _load_rest_call_policy()
+
+        class Harness(rest_call_policy):
+            _number_of_retries = 1
+
+        action_result = RestCallActionResult()
+        status, response = Harness()._make_rest_call(
+            action_result,
+            "https://graph.microsoft.com/v1.0/messages?$skiptoken=next",
+            allow_redirects=False,
+        )
+
+        self.assertEqual(status, phantom_stub.APP_ERROR)
+        self.assertIsNone(response)
+        self.assertFalse(requests_stub.kwargs["allow_redirects"])
+        self.assertIn("Refusing to follow a redirect", action_result.message)
+
+    def test_next_link_calls_disable_redirects_including_token_retry(self):
+        source = CONNECTOR.read_text()
+        tree = ast.parse(source)
+        helper = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_make_rest_call_helper")
+        rest_calls = [
+            node
+            for node in ast.walk(helper)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_make_rest_call"
+        ]
+
+        self.assertEqual(len(rest_calls), 2)
+        for call in rest_calls:
+            redirect_keyword = next((keyword for keyword in call.keywords if keyword.arg == "allow_redirects"), None)
+            self.assertIsNotNone(redirect_keyword)
+            self.assertEqual(ast.unparse(redirect_keyword.value), "not bool(nextLink)")
 
     def test_latest_first_poll_persists_continuation_before_checkpoint(self):
         source = CONNECTOR.read_text()

--- a/tests/test_validation_followup.py
+++ b/tests/test_validation_followup.py
@@ -120,6 +120,46 @@ def _load_rest_call_policy():
     return namespace["RestCallPolicy"], requests_stub, PhantomStub
 
 
+def _load_oauth_start_handler(initial_state):
+    source = CONNECTOR.read_text()
+    tree = ast.parse(source)
+    handler = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_handle_oauth_start")
+    state_store = deepcopy(initial_state)
+    saved_states = []
+
+    class HttpResponseStub:
+        def __init__(self, body="", content_type=None, status=200):
+            self.body = body
+            self.content_type = content_type
+            self.status_code = status
+            self.headers = {}
+
+        def __setitem__(self, key, value):
+            self.headers[key] = value
+
+    class PhantomStub:
+        APP_SUCCESS = 0
+
+    def load_state(asset_id):
+        return deepcopy(state_store)
+
+    def save_state(state, asset_id):
+        state_store.clear()
+        state_store.update(deepcopy(state))
+        saved_states.append(deepcopy(state))
+        return PhantomStub.APP_SUCCESS
+
+    namespace = {
+        "hmac": __import__("hmac"),
+        "HttpResponse": HttpResponseStub,
+        "phantom": PhantomStub,
+        "_load_app_state": load_state,
+        "_save_app_state": save_state,
+    }
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[handler], type_ignores=[])), str(CONNECTOR), "exec"), namespace)
+    return namespace["_handle_oauth_start"], state_store, saved_states
+
+
 class PollingActionResult:
     def __init__(self):
         self.status = 0
@@ -221,6 +261,42 @@ class ValidationFollowupTests(unittest.TestCase):
             redirect_keyword = next((keyword for keyword in call.keywords if keyword.arg == "allow_redirects"), None)
             self.assertIsNotNone(redirect_keyword)
             self.assertEqual(ast.unparse(redirect_keyword.value), "not bool(nextLink)")
+
+    def test_oauth_start_requires_and_consumes_one_time_nonce(self):
+        handler, state_store, saved_states = _load_oauth_start_handler(
+            {
+                "start_nonce": "unguessable-start-nonce",
+                "flow_nonce": "provider-callback-nonce",
+                "admin_consent_url": "https://login.microsoftonline.com/tenant/adminconsent?state=secret",
+            }
+        )
+
+        request = type("Request", (), {"GET": {"asset_id": "123", "start_nonce": "wrong"}})()
+        rejected = handler(request, [])
+        self.assertEqual(rejected.status_code, 400)
+        self.assertFalse(saved_states)
+        self.assertIn("start_nonce", state_store)
+
+        request.GET["start_nonce"] = "unguessable-start-nonce"
+        accepted = handler(request, [])
+        self.assertEqual(accepted.status_code, 302)
+        self.assertEqual(accepted.headers["Location"], state_store["admin_consent_url"])
+        self.assertNotIn("start_nonce", state_store)
+        self.assertEqual(len(saved_states), 1)
+
+        replayed = handler(request, [])
+        self.assertEqual(replayed.status_code, 400)
+        self.assertEqual(len(saved_states), 1)
+
+    def test_generated_oauth_start_url_includes_nonce(self):
+        source = CONNECTOR.read_text()
+        tree = ast.parse(source)
+        handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_get_consent")
+        handler_source = ast.get_source_segment(source, handler)
+
+        self.assertIn('app_state["start_nonce"] = start_nonce', handler_source)
+        self.assertIn('"start_nonce": start_nonce', handler_source)
+        self.assertLess(handler_source.index('app_state["start_nonce"]'), handler_source.index("_save_app_state(app_state"))
 
     def test_latest_first_poll_persists_continuation_before_checkpoint(self):
         source = CONNECTOR.read_text()

--- a/tests/test_validation_followup.py
+++ b/tests/test_validation_followup.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ast
+import unittest
+import urllib.parse
+from pathlib import Path
+
+
+CONNECTOR = Path(__file__).resolve().parents[1] / "office365_connector.py"
+
+
+def _load_quote_helper():
+    source = CONNECTOR.read_text()
+    tree = ast.parse(source)
+    helper = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_quote_path_segment")
+    namespace = {"urllib": urllib}
+    exec(compile(ast.fix_missing_locations(ast.Module(body=[helper], type_ignores=[])), str(CONNECTOR), "exec"), namespace)
+    return namespace["_quote_path_segment"]
+
+
+class ValidationFollowupTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.quote_segment = staticmethod(_load_quote_helper())
+
+    def test_path_helper_rejects_dot_segments_after_repeated_decoding(self):
+        for value in (".", "..", "%2e", "%2e%2e", "%252e%252e", "%25252e%25252e"):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    self.quote_segment(value)
+
+    def test_path_helper_preserves_opaque_identifier_encoding(self):
+        self.assertEqual(self.quote_segment("user/name"), "user%2Fname")
+        self.assertEqual(self.quote_segment("opaque id"), "opaque%20id")
+
+    def test_attachment_upload_disables_redirects(self):
+        source = CONNECTOR.read_text()
+        tree = ast.parse(source)
+        handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_upload_large_attachment")
+        put_calls = [
+            node
+            for node in ast.walk(handler)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "put"
+        ]
+        self.assertEqual(len(put_calls), 1)
+        redirect_keyword = next((keyword for keyword in put_calls[0].keywords if keyword.arg == "allow_redirects"), None)
+        self.assertIsNotNone(redirect_keyword)
+        self.assertIsInstance(redirect_keyword.value, ast.Constant)
+        self.assertIs(redirect_keyword.value.value, False)
+
+    def test_container_completion_marker_is_written_only_after_artifacts(self):
+        source = CONNECTOR.read_text()
+        tree = ast.parse(source)
+        handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_process_email_data")
+        handler_source = ast.get_source_segment(source, handler)
+        save_artifacts_offset = handler_source.index("self.save_artifacts(artifacts)")
+        completed_offset = handler_source.index('container["data"]["ingestion_complete"] = True')
+        update_offset = handler_source.index("self._update_container(action_result, container_id, container)")
+
+        self.assertIn('"ingestion_complete": False', handler_source[:save_artifacts_offset])
+        self.assertIn('container_data.get("ingestion_complete") is True', handler_source[:save_artifacts_offset])
+        self.assertLess(save_artifacts_offset, completed_offset)
+        self.assertLess(completed_offset, update_offset)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject exact and nested-encoded dot segments through the shared Microsoft Graph path helper
- disable redirects and reject redirect responses before attachment bytes are sent to an upload-session URL
- validate Microsoft Graph pagination links and fail closed instead of following redirects
- bind both the start and callback stages of interactive OAuth to separate, single-use nonces
- mark email ingestion complete only after artifacts are saved, and retry legacy or interrupted containers that lack the marker
- preserve and resume capped latest-first polling windows before advancing the mailbox checkpoint
- add focused source and behavior regressions for each change

Each fix has its own release-note line.

## Tracking

- [PAPP-37963](https://splunk.atlassian.net/browse/PAPP-37963)
- [PSAAS-30639](https://splunk.atlassian.net/browse/PSAAS-30639) / [VULN-93364](https://splunk.atlassian.net/browse/VULN-93364)
- [PSAAS-31186](https://splunk.atlassian.net/browse/PSAAS-31186) / [VULN-93911](https://splunk.atlassian.net/browse/VULN-93911)
- [PSAAS-31187](https://splunk.atlassian.net/browse/PSAAS-31187) / [VULN-93912](https://splunk.atlassian.net/browse/VULN-93912)
- [PSAAS-32324](https://splunk.atlassian.net/browse/PSAAS-32324) / [VULN-95047](https://splunk.atlassian.net/browse/VULN-95047)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Validation

- focused validation-follow-up unit tests pass
- Python compilation passes
- full local pre-commit suite passes
- hosted pre-commit, compile, build, and coverage pass
- exact dual-reviewer source validation passes at `5dd1419f37c50bdaa8b788f0308ad66df128ed53` for the OAuth, response-derived URL, and polling findings; the path-segment finding was separately validated on its unchanged fix
- sanity failures inspected so far are shared-environment connection/DNS failures and do not reach the changed connector code

Please preserve the individual commits when merging; do not squash.

Written by Codex.
